### PR TITLE
Test refactor

### DIFF
--- a/spec/requests/favorites_request_spec.rb
+++ b/spec/requests/favorites_request_spec.rb
@@ -24,6 +24,8 @@ RSpec.describe 'Favorite recipes' do
       expect(response.status).to eq(201)
       expect(recipe).to be_a Hash
       expect(recipe.keys).to eq([:success])
+      expect(recipe.keys).to_not eq([:failure])
+      expect(recipe.keys.count).to eq(1)
       expect(recipe[:success]).to eq("Favorite added successfully")
     end
 
@@ -49,6 +51,8 @@ RSpec.describe 'Favorite recipes' do
       expect(response.status).to eq(400)
       expect(recipe).to be_a Hash
       expect(recipe.keys).to eq([:failure])
+      expect(recipe.keys).to_not eq([:success])
+      expect(recipe.keys.count).to eq(1)
       expect(recipe[:failure]).to eq("invalid key")
     end
   end
@@ -83,7 +87,9 @@ RSpec.describe 'Favorite recipes' do
 
       favorites[:data].each do |favorite|
         expect(favorite.keys).to eq([:id, :type, :attributes])
+        expect(favorite.keys.count).to eq(3)
         expect(favorite[:attributes].keys).to eq([:recipe_title, :recipe_link, :country, :created_at])
+        expect(favorite[:attributes].keys.count).to eq(4)
         expect(favorite[:id]).to be_a Integer
         expect(favorite[:type]).to eq("favorite")
         expect(favorite[:attributes]).to be_a Hash
@@ -114,6 +120,7 @@ RSpec.describe 'Favorite recipes' do
       expect(response).to_not be_successful
       expect(response.status).to eq(401)
       expect(favorites).to be_a Hash
+      expect(favorites.keys).to_not eq([:data])
     end
   end
 end

--- a/spec/requests/learning_resources_request_spec.rb
+++ b/spec/requests/learning_resources_request_spec.rb
@@ -11,15 +11,19 @@ RSpec.describe 'learning resources API request from FE', :vcr do
       expect(learning_resources).to be_a Hash
 
       expect(learning_resources[:data].keys).to eq([:id, :type, :attributes])
+      expect(learning_resources[:data].keys.count).to eq(3)
       expect(learning_resources[:data][:attributes].keys).to eq([:country, :video, :images])
+      expect(learning_resources[:data][:attributes].keys.count).to eq(3)
       expect(learning_resources[:data][:id]).to eq(nil)
       expect(learning_resources[:data][:type]).to eq("learning_resource")
       expect(learning_resources[:data][:attributes]).to be_a Hash
       expect(learning_resources[:data][:attributes][:video]).to be_a Hash
       expect(learning_resources[:data][:attributes][:video].keys).to eq([:title, :youtube_video_id])
+      expect(learning_resources[:data][:attributes][:video].keys.count).to eq(2)
       expect(learning_resources[:data][:attributes][:images]).to be_a Array
       learning_resources[:data][:attributes][:images].each do |image|
         expect(image.keys).to eq([:alt_tag, :url])
+        expect(image.keys.count).to eq(2)
       end
     end
 
@@ -36,10 +40,13 @@ RSpec.describe 'learning resources API request from FE', :vcr do
 
       expect(response).to be_successful
       expect(learning_resources).to be_a Hash
+      
       expect(learning_resources[:data][:id]).to eq(nil)
+      expect(learning_resources[:data].keys.count).to eq(3)
       expect(learning_resources[:data][:type]).to eq("learning_resource")
       expect(learning_resources[:data][:attributes]).to be_a Hash
       expect(learning_resources[:data][:attributes].keys).to eq([:country, :video, :images])
+      expect(learning_resources[:data][:attributes].keys.count).to eq(3)
       expect(learning_resources[:data][:attributes][:country]).to eq("irrelevant")
       expect(learning_resources[:data][:attributes][:video]).to eq([])
       expect(learning_resources[:data][:attributes][:images]).to eq([])

--- a/spec/requests/recipes_request_spec.rb
+++ b/spec/requests/recipes_request_spec.rb
@@ -12,7 +12,9 @@ RSpec.describe 'recipe API request from FE', :vcr do
       
       recipes[:data].each do |recipe|
         expect(recipe.keys).to eq([:id, :type, :attributes])
+        expect(recipe.keys.count).to eq(3)
         expect(recipe[:attributes].keys).to eq([:title, :url, :country, :image])
+        expect(recipe)
         expect(recipe[:id]).to eq(nil)
         expect(recipe[:type]).to eq("recipe")
         expect(recipe[:attributes]).to be_a Hash

--- a/spec/requests/recipes_request_spec.rb
+++ b/spec/requests/recipes_request_spec.rb
@@ -48,7 +48,6 @@ RSpec.describe 'recipe API request from FE', :vcr do
     end
   end
   
-
   context 'when no country is given' do
     it 'returns recipes for a random country' do
       allow(CountryService).to receive(:get_random_country)

--- a/spec/requests/recipes_request_spec.rb
+++ b/spec/requests/recipes_request_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'recipe API request from FE', :vcr do
         expect(recipe.keys).to eq([:id, :type, :attributes])
         expect(recipe.keys.count).to eq(3)
         expect(recipe[:attributes].keys).to eq([:title, :url, :country, :image])
-        expect(recipe)
+        expect(recipe[:attributes].keys.count).to eq(4)
         expect(recipe[:id]).to eq(nil)
         expect(recipe[:type]).to eq("recipe")
         expect(recipe[:attributes]).to be_a Hash
@@ -30,7 +30,9 @@ RSpec.describe 'recipe API request from FE', :vcr do
         recipes = JSON.parse(response.body, symbolize_names: true)
 
         expect(response).to be_successful
+        expect(recipes).to be_a Hash
         expect(recipes[:data]).to eq([])
+        expect(recipes.keys.count).to eq(1)
       end 
     end
   end

--- a/spec/requests/tourist_sights_request_spec.rb
+++ b/spec/requests/tourist_sights_request_spec.rb
@@ -10,10 +10,13 @@ RSpec.describe 'tourist sights API request from FE', :vcr do
 
       expect(response).to be_successful
       expect(tourist_sights).to be_a Hash
+      expect(tourist_sights.keys.count).to eq(1)
 
       tourist_sights[:data].each do |sight|
         expect(sight.keys). to eq([:id, :type, :attributes])
+        expect(sight.keys.count).to eq(3)
         expect(sight[:attributes].keys).to eq([:name, :address, :place_id])
+        expect(sight[:attributes].keys.count).to eq(3)
         expect(sight[:id]).to eq(nil)
         expect(sight[:type]).to eq("tourist_sight")
         expect(sight[:attributes]).to be_a Hash
@@ -31,10 +34,13 @@ RSpec.describe 'tourist sights API request from FE', :vcr do
       expect(CountryService).to have_received(:get_random_country)
       expect(response).to be_successful
       expect(tourist_sights).to be_a Hash
+      expect(tourist_sights.keys.count).to eq(1)
 
       tourist_sights[:data].each do |sight|
         expect(sight.keys). to eq([:id, :type, :attributes])
+        expect(sight.keys.count).to eq(3)
         expect(sight[:attributes].keys).to eq([:name, :address, :place_id])
+        expect(sight[:attributes].keys.count).to eq(3)
         expect(sight[:id]).to eq(nil)
         expect(sight[:type]).to eq("tourist_sight")
         expect(sight[:attributes]).to be_a Hash

--- a/spec/requests/user_registration_request_spec.rb
+++ b/spec/requests/user_registration_request_spec.rb
@@ -18,9 +18,12 @@ RSpec.describe 'User request APIs' do
       expect(response).to be_successful
       expect(response.status).to eq(201)
       expect(new_user).to be_a Hash
+      expect(new_user.keys.count).to eq(1)
 
       expect(new_user[:data].keys).to eq([:type, :id, :attributes])
+      expect(new_user[:data].keys.count).to eq(3)
       expect(new_user[:data][:attributes].keys).to eq([:name, :email, :api_key])
+      expect(new_user[:data][:attributes].keys.count).to eq(3)
       expect(new_user[:data][:id]).to be_a Integer
       expect(new_user[:data][:type]).to eq("user")
       expect(new_user[:data][:attributes]).to be_a Hash
@@ -43,6 +46,7 @@ RSpec.describe 'User request APIs' do
 
       expect(response).to_not be_successful
       expect(response.status).to eq(400)
+      expect(new_user.keys.count).to eq(1)
       expect(new_user[:data]).to be_an Array
       expect(new_user[:data][0]).to eq("Invalid Email")
     end


### PR DESCRIPTION
- Add `.keys.count` method to tests to account for data that is not supposed to be show to the front end